### PR TITLE
docs: Correction to ECMAScript import statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can use Toast UI Editor for React as a ECMAScript module or a CommonJS modul
 import 'codemirror/lib/codemirror.css';
 import 'tui-editor/dist/tui-editor.min.css';
 import 'tui-editor/dist/tui-editor-contents.min.css';
-import Editor from '@toast-ui/react-editor'
+import { Editor } from '@toast-ui/react-editor'
 ```
 
 * Using CommonJS module


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

As the file /src/index.js exports both Editor and Viewer the import given in the readme is incorrect.

```import Editor from '@toast-ui/react-editor'```

imports an object called Editor with props of Editor.Editor and Editor.Viewer.

This throws the following errors:

```
React.createElement: type is invalid -- expected a string (for built-in components)
        or a class/function (for composite components) but got: undefined.
        You likely forgot to export your component from the file it's defined in,
        or you might have mixed up default and named imports.
```

I've updated this to:

```import { Editor } from '@toast-ui/react-editor'```